### PR TITLE
add link to wcs documentation

### DIFF
--- a/zh-CN/v3/20.文件/050.获取上传地址.md
+++ b/zh-CN/v3/20.文件/050.获取上传地址.md
@@ -1,6 +1,6 @@
 # 上传地址获取
 
-> 上传需要同时参考网宿公司文档
+> 上传需要同时参考[网宿公司文档](https://wcs.chinanetcenter.com/document/API/FileUpload/SliceUpload)
 
 #### 上传使用的参数
 


### PR DESCRIPTION
考虑网宿有两个文档网站（另一个为不完整的[wangsu.com](https://www.wangsu.com/document/cate/644/667) ），直接给出文档链接更好
